### PR TITLE
Improve mobile navigation

### DIFF
--- a/client/src/Shared/Components/Header/index.tsx
+++ b/client/src/Shared/Components/Header/index.tsx
@@ -33,6 +33,9 @@ const listItemVariants = {
 const Header: React.FC<HeaderProps> = ({ logo, onClickOpenAccount }) => {
   const { scrollY } = useScroll();
   const [isSticky, setIsSticky] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const toggleMenu = () => setMenuOpen((prev) => !prev);
   useMotionValueEvent(scrollY, "change", (latestScrollY) => {
     if (latestScrollY > 100) {
       setIsSticky(true);
@@ -65,11 +68,15 @@ const Header: React.FC<HeaderProps> = ({ logo, onClickOpenAccount }) => {
           id='logo'
           data-version-number='3.0'
         />
+        <button className='nav__toggle' onClick={toggleMenu} aria-label='Menu'>
+          &#9776;
+        </button>
         <motion.ul
           initial='hidden'
           animate='visible'
           variants={listVariants}
-          className='nav__links'
+          className={`nav__links ${menuOpen ? "nav__links--open" : ""}`}
+          onClick={() => setMenuOpen(false)}
         >
           <motion.li variants={listItemVariants} className='nav__item'>
             <a className='nav__link' href='#section--1'>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -149,14 +149,32 @@ body {
   height: clamp(6rem, 3vw, 7rem);
   transition: all 0.3s;
 }
+.nav__toggle {
+  background: none;
+  border: none;
+  font-size: 2.5rem;
+  cursor: pointer;
+  display: block;
+}
+
 .nav__links {
   display: flex;
   flex-direction: column;
   align-items: center;
   list-style: none;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  left: 0;
+  background-color: #fff;
   visibility: hidden;
   opacity: 0;
-  transition: all 0.3s;
+  transition: opacity 0.3s ease;
+}
+
+.nav__links.nav__links--open {
+  visibility: visible;
+  opacity: 1;
 }
 
 h1 {
@@ -292,10 +310,15 @@ h4 {
     transition: all 0.3s;
   }
 
+  .nav__toggle {
+    display: none;
+  }
+
   .nav__links {
     flex-direction: row;
     opacity: 1;
     visibility: visible;
+    position: static;
   }
 
   .nav__item {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -10,7 +10,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ErrorBoundary>
       <BrowserRouter>
-        <App />
+        <AuthContextProvider>
+          <App />
+        </AuthContextProvider>
       </BrowserRouter>
     </ErrorBoundary>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- add toggle button for mobile navigation menu
- display nav items in dropdown on small screens
- show normal layout at desktop width
- wrap the app with `AuthContextProvider`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6846bef3c040832992bb5278f56df1b5